### PR TITLE
feat: add default `DidResolver`

### DIFF
--- a/lib/src/dap_resolver.dart
+++ b/lib/src/dap_resolver.dart
@@ -12,7 +12,6 @@ class DapResolver {
   DidResolver didResolver;
 
   static final _defaultMethodResolvers = [
-    DidJwkResolver(),
     DidDhtResolver(),
     DidWebResolver(),
   ];

--- a/lib/src/dap_resolver.dart
+++ b/lib/src/dap_resolver.dart
@@ -11,8 +11,18 @@ class DapResolver {
   http.Client client;
   DidResolver didResolver;
 
-  DapResolver(this.didResolver, {http.Client? client})
-      : client = client ?? http.Client();
+  static final _defaultMethodResolvers = [
+    DidJwkResolver(),
+    DidDhtResolver(),
+    DidWebResolver(),
+  ];
+
+  DapResolver({
+    DidResolver? didResolver,
+    http.Client? client,
+  })  : didResolver = didResolver ??
+            DidResolver(methodResolvers: _defaultMethodResolvers),
+        client = client ?? http.Client();
 
   Future<List<MoneyAddress>> getMoneyAddresses(Dap dap) async {
     throw UnimplementedError();

--- a/test/dap_resolver_test.dart
+++ b/test/dap_resolver_test.dart
@@ -1,6 +1,5 @@
 import 'package:dap/dap.dart';
 import 'package:test/test.dart';
-import 'package:web5/web5.dart';
 
 void main() {
   group('DapResolver.resolve', () {
@@ -8,9 +7,7 @@ void main() {
       final dap = Dap.parse('@moegrammer/didpay.me');
 
       // TODO: use mocks
-      final resolver = DapResolver(DidResolver(
-        methodResolvers: [DidWebResolver()],
-      ));
+      final resolver = DapResolver();
 
       final result = await resolver.resolve(dap);
 


### PR DESCRIPTION
adds default `DidResolver` with ~`DidJwkResolver`~, `DidDhtResolver` and `DidWebResolver` as the default method resolvers to make `DapResolver` easier to use